### PR TITLE
Update gnome module ids to make it consistant with options

### DIFF
--- a/modules/nixos/gnome/module.yml
+++ b/modules/nixos/gnome/module.yml
@@ -17,12 +17,12 @@ options:
   type: !switch
     default: false
 - label: "GSConnect"
-  id: modules.gnome.gsconnect
+  id: modules.gnome.gsconnect.enable
   description: "Enable KDE Connect integration."
   type: !switch
     default: false
 - label: "Remove Utilities"
-  id: modules.gnome.removeUtils
+  id: modules.gnome.removeUtils.enable
   description: "Disable non-essential GNOME application."
   type: !switch
     default: false


### PR DESCRIPTION
Was unable to update the properties with the module manager. 
The options in the nix-file states:
```
  options.modules.gnome = with types; {
    gsconnect.enable =
      mkEnableOption "Enable KDE Connect integration";
    removeUtils.enable =
      mkEnableOption "Remove non-essential GNOME utilities";
  };
```
This should resolve that issue, but haven't actually tested it.