### PR TITLE
move from pinentryFlavor to pinentryPackage

### DIFF
--- a/modules/nixos/gnome/default.nix
+++ b/modules/nixos/gnome/default.nix
@@ -24,7 +24,7 @@ in
     systemd.services."getty@tty1".enable = false;
     systemd.services."autovt@tty1".enable = false;
 
-    programs.gnupg.agent.pinentryFlavor = mkDefault "gnome3";
+    programs.gnupg.agent.pinentryPackage = mkDefault "pkgs.pinentry-gnome3";
 
     programs.kdeconnect = mkIf cfg.gsconnect.enable {
       package = pkgs.gnomeExtensions.gsconnect;

--- a/modules/nixos/gnome/default.nix
+++ b/modules/nixos/gnome/default.nix
@@ -24,7 +24,7 @@ in
     systemd.services."getty@tty1".enable = false;
     systemd.services."autovt@tty1".enable = false;
 
-    programs.gnupg.agent.pinentryPackage = mkDefault "pkgs.pinentry-gnome3";
+    programs.gnupg.agent.pinentryPackage = mkDefault pkgs.pinentry-gnome3;
 
     programs.kdeconnect = mkIf cfg.gsconnect.enable {
       package = pkgs.gnomeExtensions.gsconnect;


### PR DESCRIPTION
nixos-unstable (24.05+) has moved from `programs.gnupg.agent.pinentryFlavor` to `programs.gnupg.agent.pinentryPackage`. Resolves the following error:

```
error:
       Failed assertions:
       - The option definition `programs.gnupg.agent.pinentryFlavor' in `/nix/store/s4qkmnc1i0bm778y7459sgc3h9n9r6i9-mcyjkn2gqjm0bnr8nsnxq9vj250r7nnl-source/modules/nixos/gnome/default.nix' no longer has any effect; please remove it.
       Use programs.gnupg.agent.pinentryPackage instead
```