### PR TITLE
Rename hardware.pulseaudio to services.pulseaudio

### DIFF
--- a/modules/nixos/pipewire/default.nix
+++ b/modules/nixos/pipewire/default.nix
@@ -14,13 +14,15 @@ in
   };
 
   config = mkIf cfg.enable {
-    hardware.pulseaudio.enable = false;
     security.rtkit.enable = true;
-    services.pipewire = {
-      enable = true;
-      alsa.enable = true;
-      alsa.support32Bit = true;
-      pulse.enable = true;
+    services = {
+      pulseaudio.enable = false;
+      pipewire = {
+        enable = true;
+        alsa.enable = true;
+        alsa.support32Bit = true;
+        pulse.enable = true;
+      };
     };
   };
 }


### PR DESCRIPTION
Fixes the following warning when building:
> ``evaluation warning: The option 'hardware.pulseaudio' defined in `/nix/store/dlm60d2lxn4ang205adssq73h2pl9iyp-g9f45v38ddklinhip1xv4h08q19zkj57-source/modules/nixos/pipewire/default.nix' has been renamed to 'services.pulseaudio'.``