### PR TITLE
Gnome: xserver removed in module name

### DIFF
--- a/modules/nixos/gnome/default.nix
+++ b/modules/nixos/gnome/default.nix
@@ -15,10 +15,14 @@ in
   config = {
 
     # Enable the GNOME Desktop Environment.
-    services.xserver.displayManager.gdm.enable = true;
-    services.xserver.desktopManager.gnome.enable = true;
-    services.xserver.enable = true;
-    services.xserver.displayManager.gdm.wayland = true;
+    services = {
+      xserver.enable = true;
+      displayManager.gdm = {
+        enable = true;
+        wayland = true;
+      };
+      desktopManager.gnome.enable = true;
+    };
 
     # Fix GNOME autologin
     systemd.services."getty@tty1".enable = false;

--- a/modules/nixos/snowflakeos/gnome.nix
+++ b/modules/nixos/snowflakeos/gnome.nix
@@ -28,7 +28,7 @@ in
 
   config = lib.mkIf config.snowflakeos.gnome.enable {
     snowflakeos.graphical.enable = true;
-    services.xserver.desktopManager.gnome = {
+    services.desktopManager.gnome = {
       favoriteAppsOverride = lib.mkDefault ''
         [org.gnome.shell]
         favorite-apps=[ 'firefox.desktop', 'org.gnome.Geary.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.Nautilus.desktop', 'dev.vlinkz.NixSoftwareCenter.desktop' ]


### PR DESCRIPTION
Fixes #7 